### PR TITLE
Fix WGEF being broken with FAWE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+target/
+/*/dependency-reduced-pom.xml

--- a/Spigot/pom.xml
+++ b/Spigot/pom.xml
@@ -67,6 +67,18 @@
 		</repository>
 	</repositories>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.intellectualsites.bom</groupId>
+				<artifactId>bom-newest</artifactId> <!--  Ref: https://github.com/IntellectualSites/bom -->
+				<version>1.44</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>net.goldtreeservers.worldguardextraflags</groupId>
@@ -82,27 +94,31 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.sk89q.worldedit</groupId>
-			<artifactId>worldedit-core</artifactId>
-			<version>7.2.8</version>
+			<groupId>com.fastasyncworldedit</groupId>
+			<artifactId>FastAsyncWorldEdit-Core</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.sk89q.worldedit</groupId>
-			<artifactId>worldedit-bukkit</artifactId>
-			<version>7.2.8</version>
+			<groupId>com.fastasyncworldedit</groupId>
+			<artifactId>FastAsyncWorldEdit-Bukkit</artifactId>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>FastAsyncWorldEdit-Core</artifactId>
+					<groupId>*</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q.worldguard</groupId>
 			<artifactId>worldguard-core</artifactId>
-			<version>7.0.6</version>
+			<version>7.0.9</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q.worldguard</groupId>
 			<artifactId>worldguard-bukkit</artifactId>
-			<version>7.0.6</version>
+			<version>7.0.9</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/Spigot/src/main/java/net/goldtreeservers/worldguardextraflags/we/handlers/WorldEditFlagHandler.java
+++ b/Spigot/src/main/java/net/goldtreeservers/worldguardextraflags/we/handlers/WorldEditFlagHandler.java
@@ -1,5 +1,8 @@
 package net.goldtreeservers.worldguardextraflags.we.handlers;
 
+import com.sk89q.worldedit.MaxChangedBlocksException;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldguard.LocalPlayer;
 
 import com.sk89q.worldedit.WorldEditException;
@@ -17,28 +20,42 @@ import net.goldtreeservers.worldguardextraflags.flags.Flags;
 
 public class WorldEditFlagHandler extends AbstractDelegateExtent
 {
-	private final LocalPlayer player;
+    private final LocalPlayer player;
 
-	private final RegionManager regionManager;
-	
-	public WorldEditFlagHandler(World world, Extent extent, LocalPlayer player, RegionManager regionManager)
-	{
-		super(extent);
+    private final RegionManager regionManager;
 
-		this.player = player;
+    public WorldEditFlagHandler(World world, Extent extent, LocalPlayer player, RegionManager regionManager)
+    {
+        super(extent);
 
-		this.regionManager = regionManager;
-	}
+        this.player = player;
 
-	@Override
+        this.regionManager = regionManager;
+    }
+
+    @Override
     public boolean setBlock(BlockVector3 location, BlockStateHolder block) throws WorldEditException
     {
-    	ApplicableRegionSet regions = this.regionManager.getApplicableRegions(location);
-    	if (regions.queryState(this.player, Flags.WORLDEDIT) != State.DENY)
-    	{
-    		return super.setBlock(location, block);
-    	}
-    	
-    	return false;
+        ApplicableRegionSet regions = this.regionManager.getApplicableRegions(location);
+        if (regions.queryState(this.player, Flags.WORLDEDIT) != State.DENY)
+        {
+            return super.setBlock(location, block);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int setBlocks(Region region, Pattern pattern) throws MaxChangedBlocksException
+    {
+        for (BlockVector3 position : region.clone())
+        {
+            ApplicableRegionSet regions = this.regionManager.getApplicableRegions(position);
+            if (regions.queryState(this.player, Flags.WORLDEDIT) != State.DENY)
+            {
+                return super.setBlocks(region, pattern);
+            }
+        }
+        return 0;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.10.1</version>
+            <version>3.13.0</version>
             <configuration>
                <source>17</source>
                <target>17</target>


### PR DESCRIPTION
Unfortunately, FAWE changed how some of their commands work, such as //set. Now, with `AbstractDelegateEvent`, it is under a new `setBlocks` method. I was able to implement the new function FAWE uses. Note that the old one is actually used for some other commands such as //sphere so it is still needed. Stock WE still uses that too. Even though I had to replace regular WE with FAWE, it still does support stock WE. I have no idea why FAWE went fixing things that weren't broken, but this adds support for newer builds of FAWE